### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ can help out to understand the internals of this library.
 
 ## Requirements
 - php: ^7.3
-- ext-rdkafka: ^4.0.0
+- ext-rdkafka: >=4.0.0
+- librdkafka: >=1.0.0 (might work with `0.11.6` if you overload the default error callback
 
 ## Installation
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ can help out to understand the internals of this library.
 ## Requirements
 - php: ^7.3
 - ext-rdkafka: >=4.0.0
-- librdkafka: >=1.0.0 (might work with `0.11.6` if you overload the default error callback
+- librdkafka: >=0.11.6 (if you use `<librdkafka:1.x` please define your own error callback)
 
 ## Installation
 ```


### PR DESCRIPTION
I will check if it works with `librdkafka:0.11.6` if we overload the default error callback, if not i will adjust the note to `>=librdkafka:1.0.0`