### PR TITLE
expose original error and exception

### DIFF
--- a/src/Exception/KafkaProducerTransactionAbortException.php
+++ b/src/Exception/KafkaProducerTransactionAbortException.php
@@ -7,5 +7,5 @@ namespace Jobcloud\Kafka\Exception;
 class KafkaProducerTransactionAbortException extends \Exception
 {
     public const TRANSACTION_REQUIRES_ABORT_EXCEPTION_MESSAGE =
-        'Produce failed. You need to abort your current transaction and start a new one';
+        'Produce failed. You need to abort your current transaction and start a new one (%s)';
 }

--- a/src/Exception/KafkaProducerTransactionFatalException.php
+++ b/src/Exception/KafkaProducerTransactionFatalException.php
@@ -7,5 +7,5 @@ namespace Jobcloud\Kafka\Exception;
 class KafkaProducerTransactionFatalException extends \Exception
 {
     public const FATAL_TRANSACTION_EXCEPTION_MESSAGE =
-        'Produce failed with a fatal error. This producer instance cannot be used anymore.';
+        'Produce failed with a fatal error. This producer instance cannot be used anymore (%s)';
 }

--- a/src/Exception/KafkaProducerTransactionRetryException.php
+++ b/src/Exception/KafkaProducerTransactionRetryException.php
@@ -6,5 +6,5 @@ namespace Jobcloud\Kafka\Exception;
 
 class KafkaProducerTransactionRetryException extends \Exception
 {
-    public const RETRIABLE_TRANSACTION_EXCEPTION_MESSAGE = 'Produce failed but can be retried';
+    public const RETRIABLE_TRANSACTION_EXCEPTION_MESSAGE = 'Produce failed but can be retried (%s)';
 }

--- a/src/Producer/KafkaProducer.php
+++ b/src/Producer/KafkaProducer.php
@@ -255,18 +255,33 @@ final class KafkaProducer implements KafkaProducerInterface
     {
         if (true === $e->isRetriable()) {
             throw new KafkaProducerTransactionRetryException(
-                KafkaProducerTransactionRetryException::RETRIABLE_TRANSACTION_EXCEPTION_MESSAGE
+                sprintf(
+                    KafkaProducerTransactionRetryException::RETRIABLE_TRANSACTION_EXCEPTION_MESSAGE,
+                    $e->getMessage()
+                ),
+                $e->getCode(),
+                $e
             );
         } elseif (true === $e->transactionRequiresAbort()) {
             throw new KafkaProducerTransactionAbortException(
-                KafkaProducerTransactionAbortException::TRANSACTION_REQUIRES_ABORT_EXCEPTION_MESSAGE
+                sprintf(
+                    KafkaProducerTransactionAbortException::TRANSACTION_REQUIRES_ABORT_EXCEPTION_MESSAGE,
+                    $e->getMessage()
+                ),
+                $e->getCode(),
+                $e
             );
         } else {
             $this->transactionInitialized = false;
             // according to librdkafka documentation, everything that is not retriable, abortable or fatal is fatal
             // fatal errors (so stated), need the producer to be destroyed
             throw new KafkaProducerTransactionFatalException(
-                KafkaProducerTransactionFatalException::FATAL_TRANSACTION_EXCEPTION_MESSAGE
+                sprintf(
+                    KafkaProducerTransactionFatalException::FATAL_TRANSACTION_EXCEPTION_MESSAGE,
+                    $e->getMessage()
+                ),
+                $e->getCode(),
+                $e
             );
         }
     }


### PR DESCRIPTION
Helps debugging things like #61 by exposing the original message and the adding the original exception