### PR TITLE
allow custom configs and hard coded values only fallback

### DIFF
--- a/src/Producer/KafkaProducerBuilder.php
+++ b/src/Producer/KafkaProducerBuilder.php
@@ -157,8 +157,8 @@ final class KafkaProducerBuilder implements KafkaProducerBuilderInterface
         }
 
         //Thread termination improvement (https://github.com/arnaud-lb/php-rdkafka#performance--low-latency-settings)
-        $this->config['socket.timeout.ms'] = '50';
-        $this->config['queue.buffering.max.ms'] = '1';
+        $this->config['socket.timeout.ms'] = $this->config['socket.timeout.ms'] ?? '50';
+        $this->config['queue.buffering.max.ms'] = $this->config['queue.buffering.max.ms'] ?? '1';
 
         if (function_exists('pcntl_sigprocmask')) {
             pcntl_sigprocmask(SIG_BLOCK, array(SIGIO));


### PR DESCRIPTION
i added the support to set the configs "socket.timeout.ms" and "queue.buffering.max.ms" to custom values. the previously hardcoded values will be set as default if no value is provided